### PR TITLE
tar.cpp 去掉tar_extract方法多余参数，tar.h添加extract_entry方法的参数

### DIFF
--- a/tar.cpp
+++ b/tar.cpp
@@ -1013,7 +1013,7 @@ int tar_update(const int fd, struct tar_t ** archive, const size_t filecount, co
     return all ? 0 : -1;
 }
 
-int tar_extract(const int fd, struct tar_t * archive, const size_t filecount, const char * files[], const char verbosity, std::string customUnTarPath) {
+int tar_extract(const int fd, struct tar_t * archive, const size_t filecount, const char * files[], const char verbosity) {
     int ret = 0;
     // extract entries with given names
     std::string customUnTarPath = "";

--- a/tar.h
+++ b/tar.h
@@ -150,7 +150,7 @@ int ls_entry(FILE * f, struct tar_t * archive, const size_t filecount, const cha
 
 // extracts a single entry
 // expects file descriptor offset to already be set to correct location
-int extract_entry(const int fd, struct tar_t * entry, const char verbosity);
+int extract_entry(const int fd, struct tar_t * entry, const char verbosity, std::string customUnTarPath);
 
 // write entries to a tar file
 int write_entries(const int fd, struct tar_t ** archive, struct tar_t ** head, const size_t filecount, const char * files[], int * offset, const char verbosity);


### PR DESCRIPTION
tar.cpp 去掉tar_extract方法多余参数，tar.h添加extract_entry方法的参数